### PR TITLE
Work Dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 coverage.txt
 
 # Runtime
+events.db
 events.sqlite
 
 # Config

--- a/cmd/mmsd/main.go
+++ b/cmd/mmsd/main.go
@@ -103,7 +103,8 @@ func main() {
 				nats.PrintAndDie(fmt.Sprintf("nats server failed: %s for server: mmsd-nats-server-%s", err, productionHubName))
 			}
 
-			cacheDB, err := server.NewDB(fmt.Sprint(filepath.Join(ctx.String("work-dir"), dbFile)))
+			dbPath := fmt.Sprint(filepath.Join(ctx.String("work-dir"), dbFile))
+			cacheDB, err := server.NewDB(dbPath)
 			if err != nil {
 				log.Fatalf("could not open cache db: %s", err)
 			}


### PR DESCRIPTION
This PR adds a `--work-dir` flag to replace the `--pstorage` and `--config` flags. The assumption is that each instance of `mmsd` should have a dedicated directory where its persistent and config files are stored. The flag is optional and defaults to `.`.

Since this will also be needed by the `mms_authorized_keys` file, it would be a bit overkill to have a flag for each of these files.

The `events.sqlite` file is also renamed to the more standard `events.db`, although that can be debated.

This PR relates to #93.
