### PR TITLE
API key authentication

### DIFF
--- a/cmd/mms/commands.go
+++ b/cmd/mms/commands.go
@@ -31,7 +31,7 @@ import (
 func listAllEvents() func(*cli.Context) error {
 	return func(ctx *cli.Context) error {
 		events := []*mms.ProductEvent{}
-		newEvents, err := mms.ListProductEvents(ctx.String("prduction-hub"), mms.Options{})
+		newEvents, err := mms.ListProductEvents(ctx.String("production-hub"), mms.Options{})
 		if err != nil {
 			return fmt.Errorf("failed to access events: %v", err)
 		}
@@ -81,7 +81,6 @@ func postEvent() func(*cli.Context) error {
 		// Create a http-request to post the payload
 		httpReq, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonStr))
 
-		// Hardcoded Api-Key, maybe in productEvent?
 		httpReq.Header.Set("Api-Key", ctx.String("api-key"))
 		httpReq.Header.Set("Content-Type", "application/json")
 
@@ -97,8 +96,8 @@ func postEvent() func(*cli.Context) error {
 		if httpResp.StatusCode != http.StatusCreated {
 			log.Fatalf("Product event not posted: %s", httpResp.Status)
 		}
-		return nil
 
+		return nil
 	}
 }
 

--- a/cmd/mms/commands.go
+++ b/cmd/mms/commands.go
@@ -82,7 +82,7 @@ func postEvent() func(*cli.Context) error {
 		httpReq, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonStr))
 
 		// Hardcoded Api-Key, maybe in productEvent?
-		httpReq.Header.Set("Api-Key", "HARDCODED APIKEY CHANGE")
+		httpReq.Header.Set("Api-Key", ctx.String("api-key"))
 		httpReq.Header.Set("Content-Type", "application/json")
 
 		// Create a http connection to the api.

--- a/cmd/mms/main.go
+++ b/cmd/mms/main.go
@@ -46,6 +46,10 @@ func main() {
 
 	postFlags := []cli.Flag{
 		altsrc.NewStringFlag(&cli.StringFlag{
+			Name:  "api-key",
+			Usage: "The authorized API key",
+		}),
+		altsrc.NewStringFlag(&cli.StringFlag{
 			Name:    "production-hub", // HTTP
 			Usage:   "The production hub HTTP URL",
 			EnvVars: []string{"MMS_PRODUCTION_HUB"},

--- a/cmd/mmsd/main.go
+++ b/cmd/mmsd/main.go
@@ -211,7 +211,7 @@ func generateAPIKey() func(*cli.Context) error {
 		}
 
 		// Save the new key entry
-		err = server.AddStateApiKey(stateDB, apiKey, ctx.String("message"))
+		err = server.AddNewApiKey(stateDB, apiKey, ctx.String("message"))
 		if err != nil {
 			log.Fatalf("error in state db: %s", err)
 		}

--- a/cmd/mmsd/main.go
+++ b/cmd/mmsd/main.go
@@ -216,6 +216,8 @@ func generateAPIKey() func(*cli.Context) error {
 			log.Fatalf("error in state db: %s", err)
 		}
 
+		fmt.Printf("Generated Key: %s\n", apiKey)
+
 		return nil
 	}
 }

--- a/cmd/mmsd/main.go
+++ b/cmd/mmsd/main.go
@@ -216,7 +216,7 @@ func generateAPIKey() func(*cli.Context) error {
 			log.Fatalf("error in state db: %s", err)
 		}
 
-		fmt.Printf("Generated Key: %s\n", apiKey)
+		log.Printf("Generated Key: %s\n", apiKey)
 
 		return nil
 	}

--- a/cmd/mmsd/main.go
+++ b/cmd/mmsd/main.go
@@ -36,14 +36,14 @@ import (
 
 const productionHubName = "default"
 const authKeysFile = "mms_authorized_keys"
+const confFile = "mmsd_config.yml"
+const dbCacheFile = "events.db"
+const dbStateFile = "state.db"
 
 func main() {
 
 	var err error
 	var hubID string
-	var confFile string = "mmsd_config.yml"
-	var dbCacheFile string = "events.db"
-	var dbStateFile string = "state.db"
 
 	// Create an identifier
 	hubID, err = mms.MakeHubIdentifier()
@@ -109,13 +109,13 @@ func main() {
 			cachePath := fmt.Sprint(filepath.Join(ctx.String("work-dir"), dbCacheFile))
 			cacheDB, err := server.NewCacheDB(cachePath)
 			if err != nil {
-				log.Fatalf("could not open cache db: %s", err)
+				log.Fatalf("could not open events db: %s", err)
 			}
 
 			statePath := fmt.Sprint(filepath.Join(ctx.String("work-dir"), dbStateFile))
 			stateDB, err := server.NewStateDB(statePath)
 			if err != nil {
-				log.Fatalf("could not open cache db: %s", err)
+				log.Fatalf("could not open state db: %s", err)
 			}
 
 			templates := server.CreateTemplates()
@@ -136,6 +136,7 @@ func main() {
 						Name:    "message",
 						Aliases: []string{"m"},
 						Usage:   "A descriptive message for the key",
+						Value:   "Unnamed key",
 					}),
 				},
 				Action: generateAPIKey(),
@@ -188,6 +189,11 @@ func startWebServer(webService *server.Service, apiURL string) {
 
 func generateAPIKey() func(*cli.Context) error {
 	return func(ctx *cli.Context) error {
+
+		// Seeding the random generator for each call may be risky since it may produce the same
+		// seed twice if the time resolution is low and the function is called often. However, the
+		// function is only called once in a single instance of mmsd, and the database should error
+		// on a duplicate key entry.
 		rand.Seed(time.Now().UnixNano())
 
 		// Generate the key
@@ -195,27 +201,19 @@ func generateAPIKey() func(*cli.Context) error {
 		for i := range byteKey {
 			byteKey[i] = byte(rand.Intn(255))
 		}
-
 		apiKey := base64.StdEncoding.EncodeToString([]byte(byteKey))
 
-		// Write the File
-		outFile, err := os.OpenFile(authKeysFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0600)
+		// Open the database
+		statePath := fmt.Sprint(filepath.Join(ctx.String("work-dir"), dbStateFile))
+		stateDB, err := server.NewStateDB(statePath)
 		if err != nil {
-			panic(err)
+			log.Fatalf("could not open state db: %s", err)
 		}
 
-		defer outFile.Close()
-
-		keyMsg := ctx.String("message")
-		if keyMsg == "" {
-			keyMsg = "Unnamed key"
-		}
-		keyMsg = fmt.Sprintf("%s (%s)", keyMsg, time.Now().Format(time.RFC3339))
-
-		fileEntry := fmt.Sprintf("api-key %s # %s\n", apiKey, keyMsg)
-		fmt.Printf("Generated: %s", fileEntry)
-		if _, err = outFile.WriteString(fileEntry); err != nil {
-			panic(err)
+		// Save the new key entry
+		err = server.AddStateApiKey(stateDB, apiKey, ctx.String("message"))
+		if err != nil {
+			log.Fatalf("error in state db: %s", err)
 		}
 
 		return nil

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -171,6 +171,13 @@ func (service *Service) postEventHandler(httpRespW http.ResponseWriter, httpReq 
 		return
 	}
 
+	validKey, err := ValidateApiKey(service.stateDB, apiKey)
+	if !validKey {
+		http.Error(httpRespW, "Unauthorized API key submitted", http.StatusUnauthorized)
+		log.Print("Unauthorized: API key not accepted")
+		return
+	}
+
 	payLoad, err = ioutil.ReadAll(httpReq.Body)
 	if err != nil {
 		http.Error(httpRespW, fmt.Sprintf("%v", err), http.StatusInternalServerError)

--- a/internal/server/state.go
+++ b/internal/server/state.go
@@ -31,13 +31,13 @@ func NewStateDB(filePath string) (*sql.DB, error) {
 	return createStateDB(filePath)
 }
 
-func saveApiKey(db *sql.DB, apiKey string, keyMsg string) error {
+func AddStateApiKey(db *sql.DB, apiKey string, keyMsg string) error {
 
 	insertSQL := `INSERT INTO api_keys (apiKey, createdDate, createMsg) VALUES (?, ?, ?)`
 	statement, err := db.Prepare(insertSQL)
 	_, err = statement.Exec(apiKey, time.Now().Format(time.RFC3339), keyMsg)
 	if err != nil {
-		return fmt.Errorf("failed to store event in db: %s", err)
+		return fmt.Errorf("failed to add api key to db: %s", err)
 	}
 
 	return nil

--- a/internal/server/state.go
+++ b/internal/server/state.go
@@ -73,6 +73,9 @@ func createStateDB(dbFilePath string) (*sql.DB, error) {
 		"lastUsed" TEXT,
 		"createMsg" TEXT,
 		PRIMARY KEY("apiKey")
+	);
+	CREATE INDEX IF NOT EXISTS "api_keys_idx" ON "api_keys" (
+		"apiKey"
 	);`
 
 	_, err = db.Exec(createTable)

--- a/internal/server/state.go
+++ b/internal/server/state.go
@@ -31,8 +31,7 @@ func NewStateDB(filePath string) (*sql.DB, error) {
 	return createStateDB(filePath)
 }
 
-func AddStateApiKey(db *sql.DB, apiKey string, keyMsg string) error {
-
+func AddNewApiKey(db *sql.DB, apiKey string, keyMsg string) error {
 	insertSQL := `INSERT INTO api_keys (apiKey, createdDate, createMsg) VALUES (?, ?, ?)`
 	statement, err := db.Prepare(insertSQL)
 	_, err = statement.Exec(apiKey, time.Now().Format(time.RFC3339), keyMsg)
@@ -41,6 +40,18 @@ func AddStateApiKey(db *sql.DB, apiKey string, keyMsg string) error {
 	}
 
 	return nil
+}
+
+func ValidateApiKey(db *sql.DB, apiKey string) (bool, error) {
+	checkSQL := `UPDATE api_keys SET lastUsed = ? WHERE apiKey = ?`
+	statement, err := db.Prepare(checkSQL)
+	result, err := statement.Exec(time.Now().Format(time.RFC3339), apiKey)
+	if err != nil {
+		return false, fmt.Errorf("failed to update api key record in db: %s", err)
+	}
+	nRows, err := result.RowsAffected()
+
+	return nRows == 1, err
 }
 
 func createStateDB(dbFilePath string) (*sql.DB, error) {


### PR DESCRIPTION
This PR connects the API key generator to the new `state.db` file and uses the key entries to validate posted events. The api-key must be sent as `--api-key` on the command line of the client, or can be saved to the config file.