### PR TITLE
Add command line option for sqlite cleaning

### DIFF
--- a/cmd/mmsd/main.go
+++ b/cmd/mmsd/main.go
@@ -331,6 +331,25 @@ func main() {
 					return nil
 				},
 			},
+
+			{
+				Name:    "delete-old-events",
+				Aliases: []string{"del"},
+				Usage:   "Delete old events ",
+				Action: func(ctx *cli.Context) error {
+
+					eventsPath := fmt.Sprint(filepath.Join(ctx.String("work-dir"), dbEventsFile))
+					eventsDB, err := server.NewEventsDB(eventsPath)
+					if err != nil {
+						log.Fatalf("could not open events db: %s", err)
+					}
+
+					if err := server.DeleteOldEventsCmd(eventsDB, time.Now().AddDate(0, 0, -3)); err != nil {
+						log.Printf("failed to delete old events from events db: %s", err)
+					}
+					return nil
+				},
+			},
 		},
 	}
 

--- a/internal/server/events_db.go
+++ b/internal/server/events_db.go
@@ -71,32 +71,6 @@ func (service *Service) DeleteOldEvents(maxAge time.Time) error {
 	return err
 }
 
-//DeleteOldEventsCmd removes events older than a specified datetime as a command line option.
-func DeleteOldEventsCmd(db *sql.DB, maxAge time.Time) error {
-
-	deleteOldEvents := `DELETE FROM events WHERE createdAt < "` + maxAge.Format(time.RFC3339) + `";`
-	statement, err := db.Prepare(deleteOldEvents)
-	if err != nil {
-		return fmt.Errorf("failed to prepare statement: %s", err)
-	}
-
-	result, err := statement.Exec()
-	if err != nil {
-		return fmt.Errorf("failed to delete event in db: %s", err)
-	}
-
-	rows, _ := result.RowsAffected()
-	_ = statement.Close()
-	if rows == 0 {
-		log.Println("No events older than 3 days")
-		return nil
-	}
-
-	log.Printf("%v rows of events deleted", rows)
-	return nil
-
-}
-
 func saveProductEvent(db *sql.DB, event *mms.ProductEvent) error {
 
 	payload, err := json.Marshal(event)

--- a/internal/server/events_db.go
+++ b/internal/server/events_db.go
@@ -71,6 +71,32 @@ func (service *Service) DeleteOldEvents(maxAge time.Time) error {
 	return err
 }
 
+//DeleteOldEventsCmd removes events older than a specified datetime as a command line option.
+func DeleteOldEventsCmd(db *sql.DB, maxAge time.Time) error {
+
+	deleteOldEvents := `DELETE FROM events WHERE createdAt < "` + maxAge.Format(time.RFC3339) + `";`
+	statement, err := db.Prepare(deleteOldEvents)
+	if err != nil {
+		return fmt.Errorf("failed to prepare statement: %s", err)
+	}
+
+	result, err := statement.Exec()
+	if err != nil {
+		return fmt.Errorf("failed to delete event in db: %s", err)
+	}
+
+	rows, _ := result.RowsAffected()
+	_ = statement.Close()
+	if rows == 0 {
+		log.Println("No events older than 3 days")
+		return nil
+	}
+
+	log.Printf("%v rows of events deleted", rows)
+	return nil
+
+}
+
 func saveProductEvent(db *sql.DB, event *mms.ProductEvent) error {
 
 	payload, err := json.Marshal(event)


### PR DESCRIPTION
    -Added command line option "del" for deleting all the events older than 3 days.

**Summary**:

**Related issue**:

**Suggested reviewer(s)**:

**Reviewer checklist**:

* [ ] The headers of all files contain a reference to the repository license
* [ ] 100% test coverage of new code - meaning:
  * [ ] The overall test coverage increased or remained the same as before
  * [ ] Every function is accompanied with a test suite
  * [ ] Tests are both positive (testing that the function work as intended with valid data) and negative (testing that the function behaves as expected with invalid data, e.g., that correct exceptions are thrown)
  * [ ] Functions with optional arguments have separate tests for all options
* [ ] Examples are supported by doctests
* [ ] All tests are passing
* [ ] All names (e.g., files, classes, functions, variables) are explicit
* [ ] Documentation (as docstrings) is complete and understandable

The checklist is based on the S-ENDA conventions and definition of done (see [General Conventions](https://s-enda-documentation.readthedocs.io/en/latest/general_conventions.html)). The above points are not necessarily relevant to all contributions. In that case, please add a short explanation to help the reviewer.
