### PR TITLE
Made combined standard output and standard error while running a script from go .

### DIFF
--- a/cmd/mms/commands.go
+++ b/cmd/mms/commands.go
@@ -17,7 +17,6 @@ limitations under the License.
 package main
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -161,19 +160,14 @@ func createExecutableCallback(filepath string, args bool, product string) func(e
 		}
 		command.Env = append(command.Env, envVars...)
 
-		var stdout bytes.Buffer
-		var stderr bytes.Buffer
-		command.Stdout = &stdout
-		command.Stderr = &stderr
-
-		err = command.Run()
+		out, err := command.CombinedOutput()
 
 		if err != nil {
-			fmt.Println("Failed", err, stderr.String())
+			fmt.Println("Failed", err)
 			return fmt.Errorf("failed to run executable, %s", err.Error())
 		}
 
-		fmt.Println(stdout.String())
+		fmt.Println(string(out))
 		return nil
 	}
 }


### PR DESCRIPTION
…pt from go

**Summary**:

**Related issue**:

**Suggested reviewer(s)**:

**Reviewer checklist**:

* [ ] The headers of all files contain a reference to the repository license
* [ ] 100% test coverage of new code - meaning:
  * [ ] The overall test coverage increased or remained the same as before
  * [ ] Every function is accompanied with a test suite
  * [ ] Tests are both positive (testing that the function work as intended with valid data) and negative (testing that the function behaves as expected with invalid data, e.g., that correct exceptions are thrown)
  * [ ] Functions with optional arguments have separate tests for all options
* [ ] Examples are supported by doctests
* [ ] All tests are passing
* [ ] All names (e.g., files, classes, functions, variables) are explicit
* [ ] Documentation (as docstrings) is complete and understandable

The checklist is based on the S-ENDA conventions and definition of done (see [General Conventions](https://s-enda-documentation.readthedocs.io/en/latest/general_conventions.html)). The above points are not necessarily relevant to all contributions. In that case, please add a short explanation to help the reviewer.
