### PR TITLE
Overwrite jwt_db everytime mms-sidecar starts

### DIFF
--- a/internal/server/jwt_db.go
+++ b/internal/server/jwt_db.go
@@ -33,7 +33,7 @@ func NewJWTDB(filePath string, NSC_creds_location string) (*sql.DB, error) {
 
 func createJWTDB(dbFilePath string, NSC_creds_location string) (*sql.DB, error) {
 	// Create database file if it does not exist.
-	file, err := os.OpenFile(dbFilePath, os.O_CREATE, 0660)
+	file, err := os.OpenFile(dbFilePath, os.O_TRUNC, 0660)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create db file: %s", err)
 	}
@@ -114,7 +114,8 @@ func InitializeJWTDB(db *sql.DB, NSC_creds_location string) error {
 			} else {
 				_, err = statement.Exec(JWTKey, NSC_cred_path)
 				if err != nil {
-					error_string += fmt.Sprintf("failed to add JWT key to db: %s", err)
+					error_string += fmt.Sprintf("failed to add JWT key to db: %s ", err)
+					error_string += fmt.Sprintf("key: %s, path: %s.", JWTKey, NSC_cred_path)
 				}
 			}
 


### PR DESCRIPTION
**Summary**: Makes the JWT database be overwritten on mms-api startup if nats-local = false

**Related issue**:

**Suggested reviewer(s)**:

**Reviewer checklist**:

* [ ] The headers of all files contain a reference to the repository license
* [ ] 100% test coverage of new code - meaning:
  * [ ] The overall test coverage increased or remained the same as before
  * [ ] Every function is accompanied with a test suite
  * [ ] Tests are both positive (testing that the function work as intended with valid data) and negative (testing that the function behaves as expected with invalid data, e.g., that correct exceptions are thrown)
  * [ ] Functions with optional arguments have separate tests for all options
* [ ] Examples are supported by doctests
* [ ] All tests are passing
* [ ] All names (e.g., files, classes, functions, variables) are explicit
* [ ] Documentation (as docstrings) is complete and understandable

The checklist is based on the S-ENDA conventions and definition of done (see [General Conventions](https://s-enda-documentation.readthedocs.io/en/latest/general_conventions.html)). The above points are not necessarily relevant to all contributions. In that case, please add a short explanation to help the reviewer.
