### PR TITLE
Organize such that both nats core and nats jetstream can be used if choose accordingly

### DIFF
--- a/cmd/mms/commands.go
+++ b/cmd/mms/commands.go
@@ -59,7 +59,8 @@ func subscribeEventsCmd(ctx *cli.Context) error {
 		natsCreds = nats.UserCredentials(ctx.String("cred-file"))
 	}
 	queueName := ctx.String("queue-name")
-	mmsClient, err := mms.NewNatsConsumerClient(ctx.String("production-hub"), natsCreds, queueName)
+	natsLocal := ctx.Bool("nats-local")
+	mmsClient, err := mms.NewNatsConsumerClient(ctx.String("production-hub"), natsCreds, queueName, natsLocal)
 	if err != nil {
 		return fmt.Errorf("one hub event subscription failed, ending: %v", err)
 	}

--- a/cmd/mms/main.go
+++ b/cmd/mms/main.go
@@ -66,6 +66,11 @@ func run(args []string) error {
 			Usage:   "Name of NATS subject (queue) to subscribe to",
 			EnvVars: []string{"MMS_QUEUE"},
 		}),
+		altsrc.NewBoolFlag(&cli.BoolFlag{
+			Name:  "nats-local",
+			Usage: "Specify wether this MMS instance will connect to NATS-server (True) or connect to an existing NATS stream",
+			Value: true,
+		}),
 	}
 
 	postFlags := []cli.Flag{

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/BurntSushi/toml v1.3.2 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
+	github.com/cloudevents/sdk-go/protocol/nats_jetstream/v2 v2.14.0 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
 	github.com/felixge/httpsnoop v1.0.1 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cloudevents/sdk-go/protocol/nats/v2 v2.14.0 h1:cPOXwhwRb+RtHrPSs6Qmobgt4q/0e4wNBdfUjOeV9Qw=
 github.com/cloudevents/sdk-go/protocol/nats/v2 v2.14.0/go.mod h1:BQefJHVdyw9MqEG5EdualOQ/JgYMViAEzkSbAp6qCKA=
+github.com/cloudevents/sdk-go/protocol/nats_jetstream/v2 v2.14.0 h1:Iq1ivWHGtkg10E38bxQj0pbLe9C6AWhX49i+QVxUilw=
+github.com/cloudevents/sdk-go/protocol/nats_jetstream/v2 v2.14.0/go.mod h1:Kly/VEwcO3vyOY5Rd17sTALl1rtzGyPncfTHHSvA2gY=
 github.com/cloudevents/sdk-go/v2 v2.14.0 h1:Nrob4FwVgi5L4tV9lhjzZcjYqFVyJzsA56CwPaPfv6s=
 github.com/cloudevents/sdk-go/v2 v2.14.0/go.mod h1:xDmKfzNjM8gBvjaF8ijFjM1VYOVUEeUfapHMUX1T5To=
 github.com/cpuguy83/go-md2man/v2 v2.0.2 h1:p1EgwI/C7NhT0JmVkwCD2ZBK8j4aeHQX2pMHHBfMQ6w=

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -98,7 +98,7 @@ func (service *Service) setRoutes() {
 	// Events
 	service.Router.HandleFunc("/api/v1/events", service.Metrics.Endpoint("/v1/events", service.eventsHandler)).Methods("GET")
 	service.Router.Handle("/api/v1/events", proxyHeaders(service.postEventHandler)).Methods("POST")
-	
+
 	// Health of the service
 	service.Router.HandleFunc("/api/v1/healthz", HealthzHandler(service.checkHealthz))
 
@@ -235,7 +235,7 @@ func (service *Service) postEventHandler(httpRespW http.ResponseWriter, httpReq 
 		return
 	}
 
-	err = mms.MakeProductEvent(service.NatsURL, postCredentials, &pEvent, queueName)
+	err = mms.MakeProductEvent(service.NatsURL, postCredentials, &pEvent, queueName, service.NatsLocal)
 	if err != nil {
 		http.Error(httpRespW, fmt.Sprintf("%v", err), http.StatusBadRequest)
 		log.Printf("failed to create ProductEvent: %v", err)

--- a/pkg/mms/events.go
+++ b/pkg/mms/events.go
@@ -22,14 +22,16 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
 	"os/user"
 	"strings"
 	"time"
-	"io/ioutil"
+
 	cenats "github.com/cloudevents/sdk-go/protocol/nats/v2"
+	jsnats "github.com/cloudevents/sdk-go/protocol/nats_jetstream/v2"
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/google/uuid"
 	"github.com/nats-io/nats.go"
@@ -88,6 +90,7 @@ type ProductEventCallback func(e *ProductEvent) error
 type EventClient struct {
 	ceClient     cloudevents.Client
 	cenatsSender cenats.Sender
+	jsnatsSender jsnats.Sender
 }
 
 // Generate a hub indetifier
@@ -96,41 +99,65 @@ func MakeHubIdentifier() (string, error) {
 
 	hostName, err := os.Hostname()
 	if err != nil {
-		hostName = "unkown"
+		hostName = "unknown"
 	}
 
 	user, err := user.Current()
 	if err == nil {
 		userName = user.Username
 	} else {
-		userName = "unkown"
+		userName = "unknown"
 	}
 	return fmt.Sprintf("%s@%s", userName, hostName), nil
 }
 
 // NewNatsConsumerClient creates a cloudevent client for consuming MMS events from NATS.
-func NewNatsConsumerClient(natsURL string, natsCredentials nats.Option, queueName string) (*EventClient, error) {
-	eClient, err := newNATSConsumer(natsURL, natsCredentials, queueName)
-	if err != nil {
-		return nil, fmt.Errorf("failed to subscribe to events: %v", err)
-	}
+func NewNatsConsumerClient(natsURL string, natsCredentials nats.Option, queueName string, natsLocal bool) (*EventClient, error) {
+	if natsLocal {
+		eClient, err := newNATSConsumer(natsURL, natsCredentials, queueName)
+		if err != nil {
+			return nil, fmt.Errorf("failed to subscribe to events: %v", err)
+		}
 
-	return &EventClient{
-		ceClient: eClient,
-	}, nil
+		return &EventClient{
+			ceClient: eClient,
+		}, nil
+	} else {
+		eClient, err := newNATSJsConsumer(natsURL, natsCredentials, queueName)
+		if err != nil {
+			return nil, fmt.Errorf("failed to subscribe to events: %v", err)
+		}
+
+		return &EventClient{
+			ceClient: eClient,
+		}, nil
+
+	}
 }
 
 // NewNatsSenderClient creates a cloudevent client for sending MMS events to NATS.
-func NewNatsSenderClient(natsURL string, natsCredentials nats.Option, queueName string) (*EventClient, error) {
-	eClient, pEvent, err := newNATSSender(natsURL, natsCredentials, queueName)
-	if err != nil {
-		return nil, fmt.Errorf("failed to subscribe to events: %v", err)
-	}
+func NewNatsSenderClient(natsURL string, natsCredentials nats.Option, queueName string, natsLocal bool) (*EventClient, error) {
+	if natsLocal {
+		eClient, pEvent, err := newNATSSender(natsURL, natsCredentials, queueName)
+		if err != nil {
+			return nil, fmt.Errorf("failed to subscribe to events: %v", err)
+		}
 
-	return &EventClient{
-		ceClient:     eClient,
-		cenatsSender: pEvent,
-	}, nil
+		return &EventClient{
+			ceClient:     eClient,
+			cenatsSender: pEvent,
+		}, nil
+	} else {
+		eClient, pEvent, err := newNATSJsSender(natsURL, natsCredentials, queueName)
+		if err != nil {
+			return nil, fmt.Errorf("failed to subscribe to events: %v", err)
+		}
+
+		return &EventClient{
+			ceClient:     eClient,
+			jsnatsSender: pEvent,
+		}, nil
+	}
 }
 
 // WatchProductEvents will call your callback function on each incoming event from the MMS Nats server.
@@ -161,9 +188,9 @@ func ListProductEvents(apiURL string) ([]*ProductEvent, error) {
 }
 
 // MakeProductEvent prepares and sends the product event
-func MakeProductEvent(natsURL string, natsCredentials nats.Option, pEvent *ProductEvent, queueName string) error {
+func MakeProductEvent(natsURL string, natsCredentials nats.Option, pEvent *ProductEvent, queueName string, natsLocal bool) error {
 
-	mmsClient, err := NewNatsSenderClient(natsURL, natsCredentials, queueName)
+	mmsClient, err := NewNatsSenderClient(natsURL, natsCredentials, queueName, natsLocal)
 	if err != nil {
 		return fmt.Errorf("failed to create messaging service: %v", err)
 	}
@@ -224,9 +251,9 @@ func PostProductEvent(mmsdURL string, apiKey string, queueName string, pe *Produ
 }
 
 // MakeProductEvent prepares and sends the product event
-func MakeHeartBeatEvent(natsURL string, natsCredentials nats.Option, hEvent *HeartBeatEvent) error {
+func MakeHeartBeatEvent(natsURL string, natsCredentials nats.Option, hEvent *HeartBeatEvent, natsLocal bool) error {
 	// Maybe queueName for HeartBeatEvent should be heartbeat? Hardcoded to mms for now
-	mmsClient, err := NewNatsSenderClient(natsURL, natsCredentials, "mms")
+	mmsClient, err := NewNatsSenderClient(natsURL, natsCredentials, "mms", natsLocal)
 	if err != nil {
 		return fmt.Errorf("failed to create messaging service: %v", err)
 	}
@@ -298,8 +325,45 @@ func newNATSSender(natsURL string, natsCredentials nats.Option, queueName string
 	return eClient, *pEvent, nil
 }
 
+func newNATSJsSender(natsURL string, natsCredentials nats.Option, queueName string) (cloudevents.Client, jsnats.Sender, error) {
+	pEvent, err := jsnats.NewSender(natsURL, "PRODUCTDATA", queueName, cenats.NatsOptions(natsCredentials), nil)
+	if err != nil {
+		return nil, jsnats.Sender{}, fmt.Errorf("failed to create nats protocol: %v", err)
+	}
+
+	eClient, err := cloudevents.NewClient(pEvent)
+	if err != nil {
+		return nil, jsnats.Sender{}, fmt.Errorf("failed to create client, %v", err)
+	}
+
+	return eClient, *pEvent, nil
+}
+
 func newNATSConsumer(natsURL string, natsCredentials nats.Option, queueName string) (cloudevents.Client, error) {
+
 	pEvent, err := cenats.NewConsumer(natsURL, queueName, cenats.NatsOptions(natsCredentials))
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to create nats protocol, %v", err)
+	}
+
+	eClient, err := cloudevents.NewClient(pEvent)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create client, %v", err)
+	}
+
+	return eClient, nil
+}
+
+func newNATSJsConsumer(natsURL string, natsCredentials nats.Option, queueName string) (cloudevents.Client, error) {
+	since := time.Now().UTC().Add(time.Hour * time.Duration(-12))
+
+	subscribeOptions := []nats.SubOpt{
+		nats.DeliverAll(),
+		nats.StartTime(since),
+	}
+	pEvent, err := jsnats.NewConsumer(natsURL, "PRODUCTDATA", queueName, cenats.NatsOptions(natsCredentials), nil, subscribeOptions)
+
 	if err != nil {
 		return nil, fmt.Errorf("failed to create nats protocol, %v", err)
 	}

--- a/pkg/mms/events_test.go
+++ b/pkg/mms/events_test.go
@@ -131,7 +131,7 @@ func TestPostProductEventNotSuccessful(t *testing.T) {
 	}
 }
 
-func EmitProductEventMessage(t *testing.T) {
+func TestEmitProductEventMessage(t *testing.T) {
 	eClient := newMockCloudeventsClient()
 
 	event := ProductEvent{ProductionHub: "test-hub", Product: "test"}


### PR DESCRIPTION
**Summary**:closes #321 

**Related issue**:

**Suggested reviewer(s)**:

**Reviewer checklist**:

* [ ] The headers of all files contain a reference to the repository license
* [ ] 100% test coverage of new code - meaning:
  * [ ] The overall test coverage increased or remained the same as before
  * [ ] Every function is accompanied with a test suite
  * [ ] Tests are both positive (testing that the function work as intended with valid data) and negative (testing that the function behaves as expected with invalid data, e.g., that correct exceptions are thrown)
  * [ ] Functions with optional arguments have separate tests for all options
* [ ] Examples are supported by doctests
* [ ] All tests are passing
* [ ] All names (e.g., files, classes, functions, variables) are explicit
* [ ] Documentation (as docstrings) is complete and understandable

The checklist is based on the S-ENDA conventions and definition of done (see [General Conventions](https://s-enda-documentation.readthedocs.io/en/latest/general_conventions.html)). The above points are not necessarily relevant to all contributions. In that case, please add a short explanation to help the reviewer.
