### PR TITLE
Change del-events-interval 3 days --> 1 day

### DIFF
--- a/cmd/mmsd/main.go
+++ b/cmd/mmsd/main.go
@@ -142,7 +142,7 @@ func main() {
 		altsrc.NewUintFlag(&cli.UintFlag{
 			Name:  "del-events-interval",
 			Usage: "Specify the interval(days) for deleting events. Default is 3 days (deletes 3 days old events)",
-			Value: 3,
+			Value: 1,
 		}),
 	}
 


### PR DESCRIPTION
Tested by getting this output from mmsd  (Starting event loop with 1 days of event deletion Interval ...) 
ecf-prod@ppi-r8admin-a1:~$ /modules/rhel8/user-apps/mms/v0.1.3/mmsd --heartbeat-interval 60 --work-dir /home/ecf-prod/mmsdb/ppi-r8admin-a1 --api-port 8788 --nats-port 4335 --hostname 0.0.0.0
2024/01/30 10:18:52 Starting NATS server on nats://0.0.0.0:4335 ...
2024/01/30 10:18:52 Populating productstatus from the local events database ...
2024/01/30 10:18:52 Starting heartbeat sender with interval: 60 s
2024/01/30 10:18:52 Starting event loop with 1 days of event deletion Interval ...
2024/01/30 10:18:52 Starting webserver on 0.0.0.0:8788 ...
