### PR TITLE
Add coreutils to get stdbuf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG go_version=1.25
 FROM docker.io/library/golang:${go_version}-alpine${alpine_version} AS build-app
 WORKDIR /build/app
 
-RUN --mount=type=cache,target=/var/cache/apk apk add build-base ca-certificates git
+RUN --mount=type=cache,target=/var/cache/apk apk add build-base ca-certificates git coreutils
 
 RUN go telemetry off
 


### PR DESCRIPTION
**Summary**:
Stdbuf is used when running as server

**Related issue**:
https://gitlab.met.no/s-enda/container-go-mms/-/work_items/1

**Suggested reviewer(s)**:
@johtoblan 

